### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,3 +90,14 @@ installDist {
 }
 
 assemble.dependsOn installDist
+
+allprojects {
+    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+        if (!project.hasProperty("createReports")) {
+            reports.html.required = false
+            reports.junitXml.required = false
+        }
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ assemble.dependsOn installDist
 
 allprojects {
     tasks.withType(Test).configureEach {
-        maxParallelForks = 4
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
         if (!project.hasProperty("createReports")) {
             reports.html.required = false
             reports.junitXml.required = false


### PR DESCRIPTION

[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution). Gradle can run multiple test cases in parallel by setting `maxParallelForks`.

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation). We can conditionally disable it by setting `reports.html.required = false; reports.junitXml.required = false`. If you need to generate reports, add `-PcreateReports` to the end of Gradle's build command line.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
