### PR TITLE
fixed deprecation warnings on older samples

### DIFF
--- a/src/main/java/com/solace/samples/jcsmp/features/BasicReplier.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/BasicReplier.java
@@ -26,13 +26,16 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.Topic;
 import com.solacesystems.jcsmp.XMLMessageConsumer;
 import com.solacesystems.jcsmp.XMLMessageListener;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Deprecated sample, see patterns/DirectReplier instead
+ */
 public class BasicReplier {
 
     public void run(String... args) throws JCSMPException {
@@ -50,17 +53,18 @@ public class BasicReplier {
         final Topic topic = JCSMPFactory.onlyInstance().createTopic("tutorial/requests");
 
         /** Anonymous inner-class for handling publishing events */
-        final XMLMessageProducer producer = session.getMessageProducer(new JCSMPStreamingPublishEventHandler() {
-            @Override
-            public void responseReceived(String messageID) {
-                System.out.println("Producer received response for msg: " + messageID);
-            }
-
-            @Override
-            public void handleError(String messageID, JCSMPException e, long timestamp) {
-                System.out.printf("Producer received error for msg: %s@%s - %s%n", messageID, timestamp, e);
-            }
-        });
+        final XMLMessageProducer producer = session.getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+			
+			@Override
+			public void responseReceivedEx(Object key) {
+                System.out.println("Producer received response for msg: " + key.toString());
+			}
+			
+			@Override
+			public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                System.out.printf("Producer received error for msg: %s@%s - %s%n", key.toString(), timestamp, cause);
+			}
+		});
 
         /** Anonymous inner-class for request handling **/
         final XMLMessageConsumer cons = session.getMessageConsumer(new XMLMessageListener() {

--- a/src/main/java/com/solace/samples/jcsmp/features/BasicRequestor.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/BasicRequestor.java
@@ -25,7 +25,7 @@ import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPRequestTimeoutException;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.Requestor;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.Topic;
@@ -33,6 +33,9 @@ import com.solacesystems.jcsmp.XMLMessageConsumer;
 import com.solacesystems.jcsmp.XMLMessageListener;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Deprecated sample, see patterns/DirectRequestorBlocking instead
+ */
 public class BasicRequestor {
 
     public static void main(String... args) throws JCSMPException {
@@ -71,16 +74,16 @@ public class BasicRequestor {
 
         /** Anonymous inner-class for handling publishing events */
         @SuppressWarnings("unused")
-        XMLMessageProducer producer = session.getMessageProducer(new JCSMPStreamingPublishEventHandler() {
-            @Override
-            public void responseReceived(String messageID) {
-                System.out.println("Producer received response for msg: " + messageID);
-            }
-            @Override
-            public void handleError(String messageID, JCSMPException e, long timestamp) {
-                System.out.printf("Producer received error for msg: %s@%s - %s%n",
-                        messageID,timestamp,e);
-            }
+        XMLMessageProducer producer = session.getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+			@Override
+			public void responseReceivedEx(Object key) {
+                System.out.println("Producer received response for msg: " + key.toString());
+			}
+			
+			@Override
+			public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                System.out.printf("Producer received error for msg: %s@%s - %s%n", key.toString(), timestamp, cause);
+			}
         });
 
         XMLMessageConsumer consumer = session.getMessageConsumer((XMLMessageListener)null);

--- a/src/main/java/com/solace/samples/jcsmp/features/ConfirmedPublish.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/ConfirmedPublish.java
@@ -33,6 +33,11 @@ import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Slightly older sample.  New streaming correlating publisher callback passes object back, rather than long ID
+ * as before, so less need to have complicated MsgInfo data structure to track outstanding published messages.
+ * Easier to just use actual Message object as key.
+ */
 public class ConfirmedPublish {
 
     final int count = 5;
@@ -83,16 +88,6 @@ public class ConfirmedPublish {
                 System.out.printf("Message response (accepted) received for %s \n", i);
             }
             latch.countDown();
-        }
-
-        @Override
-        public void handleError(String messageID, JCSMPException cause, long timestamp) {
-            // Never called
-        }
-
-        @Override
-        public void responseReceived(String messageID) {
-            // Never called
         }
     }
 

--- a/src/main/java/com/solace/samples/jcsmp/features/QueueProducer.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/QueueProducer.java
@@ -28,11 +28,14 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Deprecated sample, see patterns/GuaranteedPublisher instead
+ */
 public class QueueProducer {
 
     public static void main(String... args) throws JCSMPException, InterruptedException {
@@ -80,16 +83,16 @@ public class QueueProducer {
 
         /** Anonymous inner-class for handling publishing events */
         final XMLMessageProducer prod = session.getMessageProducer(
-                new JCSMPStreamingPublishEventHandler() {
-                    @Override
-                    public void responseReceived(String messageID) {
-                        System.out.printf("Producer received response for msg ID #%s%n",messageID);
-                    }
-                    @Override
-                    public void handleError(String messageID, JCSMPException e, long timestamp) {
-                        System.out.printf("Producer received error for msg ID %s @ %s - %s%n",
-                                messageID,timestamp,e);
-                    }
+                new JCSMPStreamingPublishCorrelatingEventHandler() {
+        			@Override
+        			public void responseReceivedEx(Object key) {
+                        System.out.println("Producer received response for msg: " + key.toString());
+        			}
+        			
+        			@Override
+        			public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                        System.out.printf("Producer received error for msg: %s@%s - %s%n", key.toString(), timestamp, cause);
+        			}
                 });
 
         // Publish-only session is now hooked up and running!

--- a/src/main/java/com/solace/samples/jcsmp/features/TopicPublisher.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/TopicPublisher.java
@@ -23,11 +23,14 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.Topic;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Deprecated sample, see patterns/DirectPublisher or GuaranteedPublisher instead
+ */
 public class TopicPublisher {
 
     public static void main(String... args) throws JCSMPException {
@@ -66,16 +69,16 @@ public class TopicPublisher {
         final Topic topic = JCSMPFactory.onlyInstance().createTopic("tutorial/topic");
 
         /** Anonymous inner-class for handling publishing events */
-        XMLMessageProducer prod = session.getMessageProducer(new JCSMPStreamingPublishEventHandler() {
-            @Override
-            public void responseReceived(String messageID) {
-                System.out.println("Producer received response for msg: " + messageID);
-            }
-            @Override
-            public void handleError(String messageID, JCSMPException e, long timestamp) {
-                System.out.printf("Producer received error for msg: %s@%s - %s%n",
-                        messageID,timestamp,e);
-            }
+        XMLMessageProducer prod = session.getMessageProducer(new JCSMPStreamingPublishCorrelatingEventHandler() {
+			@Override
+			public void responseReceivedEx(Object key) {
+                System.out.println("Producer received response for msg: " + key.toString());
+			}
+			
+			@Override
+			public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                System.out.printf("Producer received error for msg: %s@%s - %s%n", key.toString(), timestamp, cause);
+			}
         });
         // Publish-only session is now hooked up and running!
 

--- a/src/main/java/com/solace/samples/jcsmp/features/TopicToQueueMapping.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/TopicToQueueMapping.java
@@ -31,13 +31,20 @@ import com.solacesystems.jcsmp.JCSMPException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPProperties;
 import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
 import com.solacesystems.jcsmp.Queue;
 import com.solacesystems.jcsmp.TextMessage;
 import com.solacesystems.jcsmp.Topic;
 import com.solacesystems.jcsmp.XMLMessageListener;
 import com.solacesystems.jcsmp.XMLMessageProducer;
 
+/**
+ * Deprecated sample. Best practice is to admin-configure queues with topic subscriptions
+ * using SEMP or PubSub+ Manager.  See example in folder "semp-rest-api".
+ * However, if you want your messaging API to be able to add/remove topic subscriptions on
+ * queues, this sample show that.  Note that your queue needs "modify topic" permissions
+ * to work, rather than the default "consume" permissions.
+ */
 public class TopicToQueueMapping  {
 
     final int count = 5;
@@ -114,17 +121,16 @@ public class TopicToQueueMapping  {
 
         /** Anonymous inner-class for handling publishing events */
         final XMLMessageProducer prod = session.getMessageProducer(
-                new JCSMPStreamingPublishEventHandler() {
-                    @Override
-                    public void responseReceived(String messageID) {
-                        System.out.printf("Producer received response for msg ID #%s%n",messageID);
-                    }
-
-                    @Override
-                    public void handleError(String messageID, JCSMPException e, long timestamp) {
-                        System.out.printf("Producer received error for msg ID %s @ %s - %s%n",
-                                messageID,timestamp,e);
-                    }
+                new JCSMPStreamingPublishCorrelatingEventHandler() {
+        			@Override
+        			public void responseReceivedEx(Object key) {
+                        System.out.println("Producer received response for msg: " + key.toString());
+        			}
+        			
+        			@Override
+        			public void handleErrorEx(Object key, JCSMPException cause, long timestamp) {
+                        System.out.printf("Producer received error for msg: %s@%s - %s%n", key.toString(), timestamp, cause);
+        			}
                 });
 
         TextMessage msg =  JCSMPFactory.onlyInstance().createMessage(TextMessage.class);


### PR DESCRIPTION
Flagged by user "Robert" on Solace Community, needed to update a few of the older samples to remove deprecations warnings.

Done.

https://solace.community/discussion/1153/samples-for-jcsmp-use-deprecated-classes