### PR TITLE
Changing threading in samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _site
 .DS_Store
 docs/_site
 .idea
+log/

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ sourceSets {
     main {
         java {
             srcDir 'src/main/java'
+            srcDir 'src/dist/config'  // so eclipse can find the log4j2.xml file
         }
     }
 }

--- a/semp-rest-api/curl-create-queue-with-subscription.txt
+++ b/semp-rest-api/curl-create-queue-with-subscription.txt
@@ -10,7 +10,7 @@ curl http://localhost:8080/SEMP/v2/config/msgVpns/default/queues \
   -X POST \
   -u admin:admin \
   -H "Content-type:application/json" \
-  -d '{ "queueName": "q_samples",
+  -d '{ "queueName": "q_jcsmp_sub",
         "accessType": "exclusive",
         "maxMsgSpoolUsage": 100,
         "permission": "consume",
@@ -20,7 +20,7 @@ curl http://localhost:8080/SEMP/v2/config/msgVpns/default/queues \
 
 # STEP 2 : ADD A TOPIC SUBSCRIPTION TO THE QUEUE
 
-curl http://localhost:8080/SEMP/v2/config/msgVpns/default/queues/q_samples/subscriptions \
+curl http://localhost:8080/SEMP/v2/config/msgVpns/default/queues/q_jcsmp_sub/subscriptions \
   -X POST \
   -u admin:admin \
   -H "Content-type:application/json" \

--- a/src/main/java/com/solace/samples/jcsmp/HelloWorld.java
+++ b/src/main/java/com/solace/samples/jcsmp/HelloWorld.java
@@ -59,7 +59,7 @@ public class HelloWorld {
             uniqueName = reader.readLine().trim().replaceAll("\\s+", "_");  // clean up whitespace
         }
         
-        System.out.println(API + " " + SAMPLE_NAME + " JCSMP initializing...");
+        System.out.println(API + " " + SAMPLE_NAME + " initializing...");
         // Build the properties object for initializing the JCSMP Session
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);          // host:port

--- a/src/main/java/com/solace/samples/jcsmp/patterns/DirectReplier.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/DirectReplier.java
@@ -46,7 +46,7 @@ public class DirectReplier {
             System.out.printf("Usage: %s <host:port> <message-vpn> <client-username> [password]%n%n", SAMPLE_NAME);
             System.exit(-1);
         }
-        System.out.println(SAMPLE_NAME + " initializing...");
+        System.out.println(API + " " + SAMPLE_NAME + " initializing...");
         
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);          // host:port
@@ -91,6 +91,7 @@ public class DirectReplier {
         final XMLMessageConsumer cons = session.getMessageConsumer(new XMLMessageListener() {
             @Override
             public void onReceive(BytesXMLMessage requestMsg) {
+            	// allowed to reply/publish from callback thread because this is Direct messaging
                 if (requestMsg.getDestination().getName().contains("direct/request") && requestMsg.getReplyTo() != null) {
                     System.out.printf(">> %s %s received request on '%s', generating response.%n",
                             API,SAMPLE_NAME,requestMsg.getDestination());
@@ -113,7 +114,6 @@ public class DirectReplier {
                 } else {
                     System.out.println("Received message without reply-to field");
                 }
-
             }
 
             public void onException(JCSMPException e) {
@@ -124,7 +124,7 @@ public class DirectReplier {
         // subscribe to 'solace/samples/*/direct/request' ... the * is to match any pub
         session.addSubscription(JCSMPFactory.onlyInstance().createTopic(TOPIC_PREFIX + "*/direct/request"));
         // for use with Solace HTTP MicroGateway feature, will respond to REST GET request on same URI
-        // try doing: curl -u default:default http://localhost:9000/solace/samples/rest/direct/request
+        // change Message VPN REST mode to "gateway" and try doing: curl http://localhost:9000/solace/samples/rest/direct/request
         session.addSubscription(JCSMPFactory.onlyInstance().createTopic("GET/" + TOPIC_PREFIX + "*/direct/request"));
         cons.start();
 

--- a/src/main/java/com/solace/samples/jcsmp/patterns/DirectRequestorBlocking.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/DirectRequestorBlocking.java
@@ -53,7 +53,7 @@ public class DirectRequestorBlocking {
             System.out.printf("Usage: %s <host:port> <message-vpn> <client-username> [password]%n%n", SAMPLE_NAME);
             System.exit(-1);
         }
-        System.out.println(SAMPLE_NAME + " initializing...");
+        System.out.println(API + " " + SAMPLE_NAME + " initializing...");
 
         final JCSMPProperties properties = new JCSMPProperties();
         properties.setProperty(JCSMPProperties.HOST, args[0]);          // host:port

--- a/src/main/java/com/solace/samples/jcsmp/patterns/DirectSubscriber.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/DirectSubscriber.java
@@ -98,6 +98,7 @@ public class DirectSubscriber {
         });
 
         session.addSubscription(JCSMPFactory.onlyInstance().createTopic(TOPIC_PREFIX + "*/direct/>"));
+        // add more subscriptions here if you want
         consumer.start();
         System.out.println(API + " " + SAMPLE_NAME + " connected, and running. Press [ENTER] to quit.");
         while (System.in.available() == 0 && !isShutdown) {

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
@@ -53,7 +53,7 @@ public class GuaranteedProcessor {
     static final String TOPIC_PREFIX = "solace/samples/";  // used as the topic "root"
     private static final String API = "JCSMP";
     private static final int PUBLISH_WINDOW_SIZE = 100;
-    private static final String QUEUE_NAME = "q_pers_processor";
+    private static final String QUEUE_NAME = "q_jcsmp_processor";
     
     private static volatile int msgSentCounter = 0;                 // num messages sent
     private static volatile int msgRecvCounter = 0;                 // num messages received

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
@@ -155,7 +155,7 @@ public class GuaranteedProcessor {
             }
             msgRecvCounter++;
             String inboundTopic = inboundMsg.getDestination().getName();
-            if (inboundTopic.matches(TOPIC_PREFIX + ".+?/pers/pub/.*")) {  // use of regex to match variable API level
+            if (inboundTopic.contains("/pers/pub/")) {  // simple validation of topic
                 // how to "process" the incoming message? maybe do a DB lookup? add some additional properties? or change the payload?
                 TextMessage outboundMsg = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
                 final String upperCaseTopic = inboundTopic.toUpperCase();  // as a silly example of "processing"
@@ -166,7 +166,8 @@ public class GuaranteedProcessor {
                 outboundMsg.setDeliveryMode(DeliveryMode.PERSISTENT);
                 outboundMsg.setCorrelationKey(new ProcessorCorrelationKey(inboundMsg, outboundMsg));  // need to wait for publish ACK
                 String [] inboundTopicLevels = inboundTopic.split("/",6);
-                String onwardsTopic = new StringBuilder(TOPIC_PREFIX).append("jcsmp/pers/upper/").append(inboundTopicLevels[5]).toString();
+                String onwardsTopic = new StringBuilder(TOPIC_PREFIX).append(API.toLowerCase())
+                		.append("pers/upper/").append(inboundTopicLevels[5]).toString();
                 try {
                     producer.send(outboundMsg, JCSMPFactory.onlyInstance().createTopic(onwardsTopic));
                     msgSentCounter++;

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedProcessor.java
@@ -160,7 +160,7 @@ public class GuaranteedProcessor {
                 TextMessage outboundMsg = JCSMPFactory.onlyInstance().createMessage(TextMessage.class);
                 final String upperCaseTopic = inboundTopic.toUpperCase();  // as a silly example of "processing"
                 outboundMsg.setText(upperCaseTopic);
-                if (inboundMsg.getApplicationMessageId() != null) {
+                if (inboundMsg.getApplicationMessageId() != null) {  // set the new message ID to the same as this one
                     outboundMsg.setApplicationMessageId(inboundMsg.getApplicationMessageId());  // populate for traceability
                 }
                 outboundMsg.setDeliveryMode(DeliveryMode.PERSISTENT);

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedPublisher.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedPublisher.java
@@ -124,8 +124,8 @@ public class GuaranteedPublisher {
             map.putString("sample",API + "_" + SAMPLE_NAME);
             message.setProperties(map);
             message.setCorrelationKey(message);  // used for ACK/NACK correlation locally within the API
-            String topicString = new StringBuilder(TOPIC_PREFIX)
-                    .append(API.toLowerCase()).append("/pers/pub/").append(chosenCharacter).toString();
+            String topicString = new StringBuilder(TOPIC_PREFIX).append(API.toLowerCase())
+            		.append("/pers/pub/").append(chosenCharacter).toString();
             // NOTE: publishing to topic, so make sure GuaranteedSubscriber queue is subscribed to same topic,
             //       or enable "Reject Message to Sender on No Subscription Match" the client-profile
             Topic topic = JCSMPFactory.onlyInstance().createTopic(topicString);

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedPublisher.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedPublisher.java
@@ -16,6 +16,16 @@
 
 package com.solace.samples.jcsmp.patterns;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.solacesystems.jcsmp.BytesMessage;
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import com.solacesystems.jcsmp.DeliveryMode;
@@ -35,13 +45,6 @@ import com.solacesystems.jcsmp.SessionEventArgs;
 import com.solacesystems.jcsmp.SessionEventHandler;
 import com.solacesystems.jcsmp.Topic;
 import com.solacesystems.jcsmp.XMLMessageProducer;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class GuaranteedPublisher {
     
@@ -52,6 +55,7 @@ public class GuaranteedPublisher {
     private static final int APPROX_MSG_RATE_PER_SEC = 100;
     private static final int PAYLOAD_SIZE = 512;
     
+    // remember to add log4j2.xml to your classpath
     private static final Logger logger = LogManager.getLogger();  // log4j2, but could also use SLF4J, JCL, etc.
 
     private static volatile int msgSentCounter = 0;                   // num messages sent
@@ -94,57 +98,56 @@ public class GuaranteedPublisher {
                 logger.info("*** Received a producer event: " + event);
             }
         });
-
-        ExecutorService publishThread = Executors.newSingleThreadExecutor();
-        publishThread.submit(() -> {
-            byte[] payload = new byte[PAYLOAD_SIZE];
-            System.out.println("Publishing to topic '"+ TOPIC_PREFIX + API.toLowerCase() + 
-                    "/pers/pub/...', please ensure queue has matching subscription."); 
-            try {
-                while (!isShutdown) {
-                    BytesMessage message = JCSMPFactory.onlyInstance().createMessage(BytesMessage.class);
-                    // each loop, change the payload
-                    char chosenCharacter = (char)(Math.round(msgSentCounter % 26) + 65);  // choose a "random" letter [A-Z]
-                    Arrays.fill(payload,(byte)chosenCharacter);  // fill the payload completely with that char
-                    // use a BytesMessage this sample, instead of TextMessage
-                    message.setData(payload);
-                    message.setDeliveryMode(DeliveryMode.PERSISTENT);  // required for Guaranteed
-                    message.setApplicationMessageId(UUID.randomUUID().toString());  // as an example
-                    // as another example, let's define a user property!
-                    SDTMap map = JCSMPFactory.onlyInstance().createMap();
-                    map.putString("sample","JCSMP GuaranteedPublisher");
-                    message.setProperties(map);
-                    message.setCorrelationKey(message);  // used for ACK/NACK correlation locally within the API
-                    String topicString = new StringBuilder(TOPIC_PREFIX)
-                            .append(API.toLowerCase()).append("/pers/pub/").append(chosenCharacter).toString();
-                    // NOTE: publishing to topic, so make sure GuaranteedSubscriber queue is subscribed to same topic,
-                    //       or enable "Reject Message to Sender on No Subscription Match" the client-profile
-                    Topic topic = JCSMPFactory.onlyInstance().createTopic(topicString);
-                    producer.send(message, topic);  // message is *NOT* Guaranteed until ACK comes back to PublishCallbackHandler
-                    msgSentCounter++;
-                    try {
-                        Thread.sleep(1000 / APPROX_MSG_RATE_PER_SEC);  // do Thread.sleep(0) for max speed
-                        // Note: STANDARD Edition Solace PubSub+ broker is limited to 10k msg/s max ingress
-                    } catch (InterruptedException e) {
-                        isShutdown = true;
-                    }
-                }
-            } catch (JCSMPException e) {
-                e.printStackTrace();
-            } finally {
-                publishThread.shutdown();
-                logger.info("Publisher Thread shutdown");
-            }
-        });
-
-        System.out.println(API + " " + SAMPLE_NAME + " connected, and running. Press [ENTER] to quit.");
-        // block the main thread, waiting for a quit signal
-        while (System.in.available() == 0 && !isShutdown) {
-            Thread.sleep(1000);
+        
+        ScheduledExecutorService statsPrintingThread = Executors.newSingleThreadScheduledExecutor();
+        statsPrintingThread.scheduleAtFixedRate(() -> {
             System.out.printf("%s %s Published msgs/s: %,d%n",API,SAMPLE_NAME,msgSentCounter);  // simple way of calculating message rates
             msgSentCounter = 0;
+        }, 1, 1, TimeUnit.SECONDS);
+        
+        System.out.println(API + " " + SAMPLE_NAME + " connected, and running. Press [ENTER] to quit.");
+        byte[] payload = new byte[PAYLOAD_SIZE];  // preallocate
+        BytesMessage message = JCSMPFactory.onlyInstance().createMessage(BytesMessage.class);  // preallocate
+        System.out.println("Publishing to topic '"+ TOPIC_PREFIX + API.toLowerCase() + 
+                "/pers/pub/...', please ensure queue has matching subscription."); 
+        while (System.in.available() == 0 && !isShutdown) {  // loop until ENTER pressed, or shutdown flag
+            message.reset();  // ready for reuse
+            // each loop, change the payload as an example
+            char chosenCharacter = (char)(Math.round(msgSentCounter % 26) + 65);  // choose a "random" letter [A-Z]
+            Arrays.fill(payload,(byte)chosenCharacter);  // fill the payload completely with that char
+            // use a BytesMessage this sample, instead of TextMessage
+            message.setData(payload);
+            message.setDeliveryMode(DeliveryMode.PERSISTENT);  // required for Guaranteed
+            message.setApplicationMessageId(UUID.randomUUID().toString());  // as an example
+            // as another example, let's define a user property!
+            SDTMap map = JCSMPFactory.onlyInstance().createMap();
+            map.putString("sample",API + "_" + SAMPLE_NAME);
+            message.setProperties(map);
+            message.setCorrelationKey(message);  // used for ACK/NACK correlation locally within the API
+            String topicString = new StringBuilder(TOPIC_PREFIX)
+                    .append(API.toLowerCase()).append("/pers/pub/").append(chosenCharacter).toString();
+            // NOTE: publishing to topic, so make sure GuaranteedSubscriber queue is subscribed to same topic,
+            //       or enable "Reject Message to Sender on No Subscription Match" the client-profile
+            Topic topic = JCSMPFactory.onlyInstance().createTopic(topicString);
+            try {
+                producer.send(message, topic);
+                msgSentCounter++;
+            } catch (JCSMPException e) {  // threw from send(), only thing that is throwing here, but keep trying (unless shutdown?)
+                System.out.printf("### Caught while trying to producer.send(): %s%n",e);
+                if (e instanceof JCSMPTransportException) {  // all reconnect attempts failed
+                    isShutdown = true;  // let's quit; or, could initiate a new connection attempt
+                }
+            } finally {  // add a delay between messages
+                try {
+                    Thread.sleep(1000 / APPROX_MSG_RATE_PER_SEC);  // do Thread.sleep(0) for max speed
+                    // Note: STANDARD Edition Solace PubSub+ broker is limited to 10k msg/s max ingress
+                } catch (InterruptedException e) {
+                    isShutdown = true;
+                }
+            }
         }
-        isShutdown = true;   // will stop the publish thread
+        isShutdown = true;
+        statsPrintingThread.shutdown();  // stop printing stats
         Thread.sleep(1500);  // give time for the ACKs to arrive from the broker
         session.closeSession();
         System.out.println("Main thread quitting.");

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedSubscriber.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedSubscriber.java
@@ -40,7 +40,7 @@ import org.apache.logging.log4j.Logger;
 public class GuaranteedSubscriber {
 
     private static final String SAMPLE_NAME = GuaranteedSubscriber.class.getSimpleName();
-    private static final String QUEUE_NAME = "q_samples";
+    private static final String QUEUE_NAME = "q_jcsmp_sub";
     private static final String API = "JCSMP";
     
     private static volatile int msgRecvCounter = 0;                 // num messages received

--- a/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedSubscriber.java
+++ b/src/main/java/com/solace/samples/jcsmp/patterns/GuaranteedSubscriber.java
@@ -48,13 +48,11 @@ public class GuaranteedSubscriber {
     private static volatile boolean isShutdown = false;             // are we done?
     private static FlowReceiver flowQueueReceiver;
 
-
-    private static final Logger logger = LogManager.getLogger(GuaranteedSubscriber.class);  // log4j2, but could also use SLF4J, JCL, etc.
+    // remember to add log4j2.xml to your classpath
+    private static final Logger logger = LogManager.getLogger();  // log4j2, but could also use SLF4J, JCL, etc.
 
     /** This is the main app.  Use this type of app for receiving Guaranteed messages (e.g. via a queue endpoint). */
     public static void main(String... args) throws JCSMPException, InterruptedException, IOException {
-logger.info("THIS IS THE FIST MESSAGE. NOW SLEEP");
-Thread.sleep(10000000);
         if (args.length < 3) {  // Check command line arguments
             System.out.printf("Usage: %s <host:port> <message-vpn> <client-username> [password]%n%n", SAMPLE_NAME);
             System.exit(-1);


### PR DESCRIPTION
Some of the JCSMP samples use a separate "publish thread". This PR removes that as it caused some confusion, and put publishing back into the main thread in a loop.

Also, fixed a log4j2 classpath thing, so Eclipse can find the xml properties file.
