### PR TITLE
Contribute snippets from Arch use cases for OAuth 2.0 and OpenId Con…

### DIFF
--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.solace.samples.jcsmp.snippets;
 
 import com.solacesystems.jcsmp.JCSMPProperties;
@@ -5,6 +24,9 @@ import com.solacesystems.jcsmp.InvalidPropertiesException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPSession;
 
+/**
+ * Demonstrates how to configure a Session using properties supporting OAuth 2.0 authentication.
+ */
 public class HowToConfigureSessionUsingOAUTH2 {
 
 

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
@@ -1,0 +1,20 @@
+package com.solace.samples.jcsmp.snippets;
+
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.InvalidPropertiesException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPSession;
+
+public class HowToConfigureSessionUsingOAUTH2 {
+
+
+  public void createOauth2Session(JCSMPProperties sessionProperties, String accessToken, String issuerId) throws InvalidPropertiesException
+  {
+     sessionProperties.setProperty(JCSMPProperties.AUTHENTICATION_SCHEME, JCSMPProperties.AUTHENTICATION_SCHEME_OAUTH2);
+     sessionProperties.setProperty(JCSMPProperties.OAUTH2_ACCESS_TOKEN, accessToken);
+     sessionProperties.setProperty(JCSMPProperties.OAUTH2_ISSUER_IDENTIFIER, issuerId); 
+     final JCSMPFactory sessionFactory = JCSMPFactory.onlyInstance();
+     final JCSMPSession session = sessionFactory.createSession(sessionProperties);
+  }
+    
+}

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOpenIdConnect.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOpenIdConnect.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.solace.samples.jcsmp.snippets;
 
 import com.solacesystems.jcsmp.JCSMPProperties;
@@ -5,6 +24,9 @@ import com.solacesystems.jcsmp.InvalidPropertiesException;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPSession;
 
+/**
+ * Demonstrates how to configure a Session using properties supporting OpenId Connect authentication
+ */
 public class HowToConfigureSessionUsingOpenIdConnect {
 
   public void createOIDCSession(JCSMPProperties sessionProperties, String idToken, String accessTokenOptional) throws InvalidPropertiesException

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOpenIdConnect.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOpenIdConnect.java
@@ -1,0 +1,21 @@
+package com.solace.samples.jcsmp.snippets;
+
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.InvalidPropertiesException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPSession;
+
+public class HowToConfigureSessionUsingOpenIdConnect {
+
+  public void createOIDCSession(JCSMPProperties sessionProperties, String idToken, String accessTokenOptional) throws InvalidPropertiesException
+  {
+    sessionProperties.setProperty(JCSMPProperties.AUTHENTICATION_SCHEME, JCSMPProperties.AUTHENTICATION_SCHEME_OAUTH2);
+    sessionProperties.setProperty(JCSMPProperties.OAUTH2_ACCESS_TOKEN, accessTokenOptional);
+    sessionProperties.setProperty(JCSMPProperties.OIDC_ID_TOKEN, idToken);
+     
+    final JCSMPFactory sessionFactory = JCSMPFactory.onlyInstance();
+   
+    final JCSMPSession session =sessionFactory.createSession(sessionProperties);
+  }
+    
+}


### PR DESCRIPTION
The attached code snippets cover the use case for configuring a session using OAuth 2.0 and OpenId Connect.
We should discuss documentation.