### PR TITLE
added truststore snippet, fixed boilerplate header

### DIFF
--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionTlsKeystore.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionTlsKeystore.java
@@ -22,19 +22,19 @@ import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.JCSMPSession;
 
 /**
- * Demonstrates how to configure a Session using properties supporting OpenId Connect authentication
+ * Demonstrates how to configure a TLS Session with a specific truststore.
  */
-public class HowToConfigureSessionUsingOpenIdConnect {
+public class HowToConfigureSessionTlsKeystore {
 
-  public void createOIDCSession(JCSMPProperties sessionProperties, String idToken, String accessTokenOptional) throws InvalidPropertiesException
-  {
-    sessionProperties.setProperty(JCSMPProperties.AUTHENTICATION_SCHEME, JCSMPProperties.AUTHENTICATION_SCHEME_OAUTH2);
-    sessionProperties.setProperty(JCSMPProperties.OAUTH2_ACCESS_TOKEN, accessTokenOptional);
-    sessionProperties.setProperty(JCSMPProperties.OIDC_ID_TOKEN, idToken);
-     
-    final JCSMPFactory sessionFactory = JCSMPFactory.onlyInstance();
-   
-    final JCSMPSession session =sessionFactory.createSession(sessionProperties);
-  }
-    
+
+	public JCSMPSession create(JCSMPProperties sessionProperties) throws InvalidPropertiesException {
+
+		sessionProperties.setProperty(JCSMPProperties.SSL_TRUST_STORE, "/Users/myself/path/to/truststore.jks");
+		sessionProperties.setProperty(JCSMPProperties.SSL_TRUST_STORE_PASSWORD, "tsPassword");
+		
+		final JCSMPFactory sessionFactory = JCSMPFactory.onlyInstance();
+		final JCSMPSession session = sessionFactory.createSession(sessionProperties);
+		return session;
+	}
+
 }

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToConfigureSessionUsingOAUTH2.java
@@ -1,20 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright 2021-2022 Solace Corporation. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.solace.samples.jcsmp.snippets;

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToListenToReconnectionEvents.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToListenToReconnectionEvents.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021-2022 Solace Corporation. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.solace.samples.jcsmp.snippets;
 
 import com.solacesystems.jcsmp.JCSMPException;

--- a/src/main/java/com/solace/samples/jcsmp/snippets/TestEveryMessageSetting.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/TestEveryMessageSetting.java
@@ -1,20 +1,17 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Copyright 2021-2022 Solace Corporation. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.solace.samples.jcsmp.snippets;


### PR DESCRIPTION
As stated in https://github.com/SolaceSamples/solace-samples-java-jcsmp/issues/77  this adds a snippet to demonstrate how to specify a truststore for TLS connections.
