### PR TITLE
Update the solace-opentelemetry-jcsmp-integration to v1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,11 +75,9 @@ dependencies {
     //testImplementation 'junit:junit:4.13'
 
     //Distributed Tracing Dependency on OpenTelemetry and Solace OpenTelemetry JCSMP Integration
-    implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.0.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-api', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-sdk', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.19.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-semconv', version: '1.19.0-alpha'
+    implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.1.0'
+    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.29.0'
+    implementation group: 'io.opentelemetry', name: 'opentelemetry-semconv', version: '1.29.0-alpha'
 }
 
 sourceSets {


### PR DESCRIPTION
Update the solace-opentelemetry-jcsmp-integration to v1.1.0 and update the related OpenTelemetry dependencies versions.