### PR TITLE
SOL-61595: update SecureSession sample with in-memory truststore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,13 @@ dependencies {
     // Solace Messaging API for Java Dependencies
     implementation group: 'com.solacesystems', name: 'sol-jcsmp', version: '10.+'
     // new improved logging framework, log4j2
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.+'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.+'
     // needed to 'bridge' the JCSMP API logs from JCL to log4j
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.19.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.+'
     // include this next one if you want to use JsonLayout for log4j
     //implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
+    //implementation group: 'org.fusesource.jansi', name: 'jansi', version: '2.4.1'
 
     //implementation fileTree(dir: 'lib', include: '*.jar')  // temporary, for testing of stuff
 
@@ -121,6 +122,7 @@ def scripts = [
     'confirmedPublish':'com.solace.samples.jcsmp.features.ConfirmedPublish',
     'topicToQueueMapping':'com.solace.samples.jcsmp.features.TopicToQueueMapping',
     'dtDirectPublisher':'com/solace/samples/jcsmp/features/distributedtracing/DirectPublisherWithManualInstrumentation',
+    'GuaranteedSubscriberWithSettle':'com.solace.samples.jcsmp.patterns.GuaranteedSubscriberWithSettle',
     'dtDirectSubscriber':'com/solace/samples/jcsmp/features/distributedtracing/DirectSubscriberWithManualInstrumentation'
 ]
 // for each of those array entries, let's make a start script

--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,10 @@ dependencies {
     // Solace Messaging API for Java Dependencies
     implementation group: 'com.solacesystems', name: 'sol-jcsmp', version: '10.+'
     // new improved logging framework, log4j2
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.+'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.+'
     // needed to 'bridge' the JCSMP API logs from JCL to log4j
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.19.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.+'
     // include this next one if you want to use JsonLayout for log4j
     //implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
 
@@ -111,6 +111,7 @@ def scripts = [
     'featureQueueProvisionAndRequestActiveFlowIndication':'com.solace.samples.jcsmp.features.QueueProvisionAndRequestActiveFlowIndication',
     'featureTransactions':'com.solace.samples.jcsmp.features.Transactions',
     'featureMessageReplay':'com.solace.samples.jcsmp.features.MessageReplay',
+    'featureSecureSession':'com.solace.samples.jcsmp.features.SecureSession',
     'topicPublisher':'com.solace.samples.jcsmp.features.TopicPublisher',
     'topicSubscriber':'com.solace.samples.jcsmp.features.TopicSubscriber',
     'queueProducer':'com.solace.samples.jcsmp.features.QueueProducer',

--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,10 @@ dependencies {
     // Solace Messaging API for Java Dependencies
     implementation group: 'com.solacesystems', name: 'sol-jcsmp', version: '10.+'
     // new improved logging framework, log4j2
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.+'
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.+'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.19.0'
     // needed to 'bridge' the JCSMP API logs from JCL to log4j
-    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.+'
+    implementation group: 'org.apache.logging.log4j', name: 'log4j-jcl', version: '2.19.0'
     // include this next one if you want to use JsonLayout for log4j
     //implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.4'
 

--- a/src/dist/config/log4j2.xml
+++ b/src/dist/config/log4j2.xml
@@ -11,6 +11,11 @@
         <!--JSONLayout/-->
       </PatternLayout>
     </File>
+    <!--Solace name="solaceLogger" host="localhost" vpn="default" username="asdf" password="asdf" direct="true" appName="justTesting">
+      <PatternLayout>
+        <Pattern>%d %p whoami %c{1} [%t] %m</Pattern>
+      </PatternLayout>
+    </Solace-->
   </Appenders>
   <Loggers>
     <!-- you can dynamically set the log level from the command line using jvm system variables -->
@@ -21,6 +26,7 @@
     <Root level="${sys:root_log_level:-info}">
       <AppenderRef ref="console"/>
       <AppenderRef ref="logfile"/>
+      <!--AppenderRef ref="solaceLogger"/-->
     </Root>
   </Loggers>
 </Configuration>

--- a/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
@@ -18,6 +18,11 @@
 
 package com.solace.samples.jcsmp.features;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+
 import com.solace.samples.jcsmp.features.common.ArgParser;
 import com.solace.samples.jcsmp.features.common.SampleApp;
 import com.solace.samples.jcsmp.features.common.SecureSessionConfiguration;
@@ -151,6 +156,19 @@ public class SecureSession extends SampleApp implements XMLMessageListener, JCSM
         if (conf.getSslConnetionDowngrade() != null){
         	properties.setProperty(JCSMPProperties.SSL_CONNECTION_DOWNGRADE_TO, conf.getSslConnetionDowngrade());
         }
+        // option for in-memory trust stores and key stores:  https://docs.solace.com/API-Developer-Online-Ref-Documentation/java/com/solacesystems/jcsmp/JCSMPProperties.html
+        if (conf.getTrustStore() == null) {
+            try {
+                KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+                char[] password = "some password".toCharArray();
+                ks.load(null, password);
+                // initialize keystore here...
+                // properties.setProperty(JCSMPProperties.SSL_IN_MEMORY_TRUST_STORE, ks);
+            } catch (GeneralSecurityException | IOException e) {
+                // deal with it
+            }
+        }
+
         session = JCSMPFactory.onlyInstance().createSession(properties);
     }
 

--- a/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
@@ -157,7 +157,7 @@ public class SecureSession extends SampleApp implements XMLMessageListener, JCSM
         	properties.setProperty(JCSMPProperties.SSL_CONNECTION_DOWNGRADE_TO, conf.getSslConnetionDowngrade());
         }
         // option for in-memory trust stores and key stores:  https://docs.solace.com/API-Developer-Online-Ref-Documentation/java/com/solacesystems/jcsmp/JCSMPProperties.html
-        if (conf.getTrustStore() == null) {
+        if (conf.getTrustStore() == null && conf.getTrustStorePwd() == null) {
             try {
                 KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
                 char[] password = "some password".toCharArray();

--- a/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/SecureSession.java
@@ -160,7 +160,7 @@ public class SecureSession extends SampleApp implements XMLMessageListener, JCSM
         if (conf.getTrustStore() == null && conf.getTrustStorePwd() == null) {
             try {
                 KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-                char[] password = "some password".toCharArray();
+                char[] password = "some password".toCharArray();  // probably don't hardcode password, retreive from env variable or other secure way
                 ks.load(null, password);
                 // initialize keystore here...
                 // properties.setProperty(JCSMPProperties.SSL_IN_MEMORY_TRUST_STORE, ks);


### PR DESCRIPTION
As mentioned in Jira, this adds some text/code in the SecureSession sample to indicate how to load an in-memory truststore.  Cannot add a working example to the code as this in-memory truststore needs to be programmatically defined.
