### PR TITLE
Fix OTtel build errors after breaking changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,10 @@ dependencies {
     //Distributed Tracing Dependency on OpenTelemetry and Solace OpenTelemetry JCSMP Integration
     implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.1.0'
     implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.+'
-    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.+'
+    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.29.+'
+    // breaking changes in 1.30, need to change a lot of code since OTel moved around a TON of stuff, will fix once stable
+    //implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.+'
+    //implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv-incubating', version: '1.+'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,10 @@ dependencies {
     //Distributed Tracing Dependency on OpenTelemetry and Solace OpenTelemetry JCSMP Integration
     implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.1.0'
     implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.+'
-    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.29.+'
+    //implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.29.+'
     // breaking changes in 1.30, need to change a lot of code since OTel moved around a TON of stuff, will fix once stable
-    //implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.+'
-    //implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv-incubating', version: '1.+'
+    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.30.+'
+    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv-incubating', version: '1.30.+'
 }
 
 sourceSets {

--- a/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/GuaranteedPublisherWithCustomPropagation.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/GuaranteedPublisherWithCustomPropagation.java
@@ -45,7 +45,9 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues;
 
 /**
  * A sample that shows how to generate a Publisher/send span with Solace OpenTelemetry Integration
@@ -157,10 +159,10 @@ public class GuaranteedPublisherWithCustomPropagation {
             // Some transport attributes to include, in the SemanticAttributes name space:
             // See: https://opentelemetry.io/docs/specs/semconv/general/trace/
 
-            .setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "solace")
-            .setAttribute(SemanticAttributes.MESSAGING_OPERATION, "send")
-            .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_NAME, messageDestination.getName())
-            .setAttribute(SemanticAttributes.NET_PROTOCOL_NAME, "smf")
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "solace")
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE, MessagingOperationTypeIncubatingValues.SEND)
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, messageDestination.getName())
+            .setAttribute(NetworkAttributes.NETWORK_PROTOCOL_NAME, "smf")
 
             //.setParent(Context.current()) // set current context as parent	// empty in this case, same as .setNoParent()
             .setParent(manualContext)	// Changes things to PropagatedSpan vs SdkSpan, but doesn't show in Jaeger.
@@ -168,6 +170,7 @@ public class GuaranteedPublisherWithCustomPropagation {
             .startSpan();
                 
         try (Scope scope = sendSpan.makeCurrent()) {
+            scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
 
             // Add some OTEL Baggage (key-value store) of contextual information 
             // that can 'propagate' across multiple systems and spans by being copied from one to another.

--- a/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/GuaranteedPublisherWithManualInstrumentation.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/GuaranteedPublisherWithManualInstrumentation.java
@@ -42,7 +42,9 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.NetworkAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues;
 
 /**
  * A sample that shows how to generate a Publisher/send span with Solace OpenTelemetry Integration
@@ -139,16 +141,17 @@ public class GuaranteedPublisherWithManualInstrumentation {
             // Some transport attributes to include, in the SemanticAttributes name space:
             // See: https://opentelemetry.io/docs/specs/semconv/general/trace/
 
-            .setAttribute(SemanticAttributes.MESSAGING_SYSTEM, "solace")
-            .setAttribute(SemanticAttributes.MESSAGING_OPERATION, "send")
-            .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_NAME, messageDestination.getName())
-            .setAttribute(SemanticAttributes.NET_PROTOCOL_NAME, "smf")
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_SYSTEM, "solace")
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_OPERATION_TYPE, MessagingOperationTypeIncubatingValues.SEND)
+            .setAttribute(MessagingIncubatingAttributes.MESSAGING_DESTINATION_NAME, messageDestination.getName())
+            .setAttribute(NetworkAttributes.NETWORK_PROTOCOL_NAME, "smf")
 
             .setParent(Context.current()) // set current context as parent (empty in this case, same as .setNoParent() )
             .startSpan();
         
         // This is signalling the span to have started, timestamps automatically captured.
         try (Scope scope = sendSpan.makeCurrent()) {
+            scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
 
             // Add some OTEL Baggage (key-value store) of contextual information 
             // that can 'propagate' across multiple systems and spans by being copied from one to another.

--- a/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/TracingUtil.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/distributedtracing/TracingUtil.java
@@ -16,19 +16,19 @@
 
 package com.solace.samples.jcsmp.features.distributedtracing;
 
+import java.util.concurrent.TimeUnit;
+
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
-import io.opentelemetry.semconv.ResourceAttributes;
-import java.util.concurrent.TimeUnit;
+import io.opentelemetry.semconv.ServiceAttributes;
 
 // A class to facilitate OpenTelemetry Instrumentation. Can be commonly used across the application.
 public class TracingUtil {
@@ -39,7 +39,7 @@ public class TracingUtil {
     	
         // OpenTelemetry Resource object
         Resource resource = Resource.getDefault().merge(Resource.create(
-            Attributes.of(ResourceAttributes.SERVICE_NAME, serviceName)));
+            Attributes.of(ServiceAttributes.SERVICE_NAME, serviceName)));
 
         // OpenTelemetry provides gRPC, HTTP and NoOp span exporter.
         // Configure the endpoint details dependent on the protocol choice for your OTLP receiver endpoint
@@ -50,10 +50,10 @@ public class TracingUtil {
             .build();
 
         // If HTTP:
-        OtlpHttpSpanExporter spanExporterHttp = OtlpHttpSpanExporter.builder()
-            .setEndpoint("https://yourhost.com/opentelemetry/public/v1/traces/")
-            .addHeader("authorization", "dataKey example-key")
-            .build();
+//        OtlpHttpSpanExporter spanExporterHttp = OtlpHttpSpanExporter.builder()
+//            .setEndpoint("https://yourhost.com/opentelemetry/public/v1/traces/")
+//            .addHeader("authorization", "dataKey example-key")
+//            .build();
 
         // Use OpenTelemetry SdkTracerProvider as TracerProvider, picking between gRPC or HTTP:
         SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToImplementTracingManualInstrumentation.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToImplementTracingManualInstrumentation.java
@@ -29,9 +29,12 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapPropagator;
-import io.opentelemetry.semconv.SemanticAttributes;
-import io.opentelemetry.semconv.SemanticAttributes.MessagingDestinationKindValues;
-import io.opentelemetry.semconv.SemanticAttributes.MessagingOperationValues;
+//import io.opentelemetry.semconv.SemanticAttributes;
+//import io.opentelemetry.semconv.SemanticAttributes.MessagingDestinationKindValues;
+//import io.opentelemetry.semconv.SemanticAttributes.MessagingOperationValues;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes;
+import io.opentelemetry.semconv.incubating.MessagingIncubatingAttributes.MessagingOperationTypeIncubatingValues;
+
 import java.util.function.Consumer;
 
 public class HowToImplementTracingManualInstrumentation {
@@ -92,12 +95,9 @@ public class HowToImplementTracingManualInstrumentation {
 
     //Create a new span with a current context as parent of this span
     final Span sendSpan = tracer
-        .spanBuilder("mySolacePublisherApp" + " " + MessagingOperationValues.PROCESS)
+        .spanBuilder("mySolacePublisherApp" + " " + MessagingOperationTypeIncubatingValues.PROCESS)
         .setSpanKind(SpanKind.CLIENT)
-        // published to a topic endpoint (non temporary)
-        .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND,
-            MessagingDestinationKindValues.TOPIC)
-        .setAttribute(SemanticAttributes.MESSAGING_TEMP_DESTINATION, false)
+        .setAttribute(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, false)
         //Set more attributes as needed
         //.setAttribute(...)
         //.setAttribute(...)
@@ -146,12 +146,12 @@ public class HowToImplementTracingManualInstrumentation {
       scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
       //Create a child span and set extracted/current context as parent of this span
       final Span receiveSpan = tracer
-          .spanBuilder("mySolaceReceiverApp" + " " + MessagingOperationValues.RECEIVE)
+          .spanBuilder("mySolaceReceiverApp" + " " + MessagingOperationTypeIncubatingValues.RECEIVE)
           .setSpanKind(SpanKind.CLIENT)
           // for the case the message was received on a non temporary queue endpoint
-          .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND,
-              MessagingDestinationKindValues.QUEUE)
-          .setAttribute(SemanticAttributes.MESSAGING_TEMP_DESTINATION, false)
+//          .setAttribute(SemanticAttributes.MESSAGING_DESTINATION_KIND,
+//              MessagingDestinationKindValues.QUEUE)
+          .setAttribute(MessagingIncubatingAttributes.MESSAGING_DESTINATION_TEMPORARY, false)
           //Set more attributes as needed
           //.setAttribute(...)
           //.setAttribute(...)

--- a/src/main/java/com/solace/samples/jcsmp/snippets/HowToImplementTracingManualInstrumentation.java
+++ b/src/main/java/com/solace/samples/jcsmp/snippets/HowToImplementTracingManualInstrumentation.java
@@ -70,6 +70,7 @@ public class HowToImplementTracingManualInstrumentation {
         .extract(Context.current(), receivedMessage, getter);
     //and then set the extractedContext as current context
     try (Scope scope = extractedContext.makeCurrent()) {
+      scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
       //...
     }
   }
@@ -105,6 +106,7 @@ public class HowToImplementTracingManualInstrumentation {
 
     //set sendSpan as new current context
     try (Scope scope = sendSpan.makeCurrent()) {
+      scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
       final SolaceJCSMPTextMapSetter setter = new SolaceJCSMPTextMapSetter();
       final TextMapPropagator propagator = openTelemetry.getPropagators().getTextMapPropagator();
       //and then inject current context with send span into the message
@@ -141,6 +143,7 @@ public class HowToImplementTracingManualInstrumentation {
 
     //Set the extracted context as current context
     try (Scope scope = extractedContext.makeCurrent()) {
+      scope.equals(null);  // to not get the compile warning due to not using scope.  stupid javac
       //Create a child span and set extracted/current context as parent of this span
       final Span receiveSpan = tracer
           .spanBuilder("mySolaceReceiverApp" + " " + MessagingOperationValues.RECEIVE)


### PR DESCRIPTION
OpenTelemetry made breaking changes to their OTel semantic conventions library, which subseqently caused JCSMP samples to break as we were pulling in the latest version.  This small PR just sets/hardcodes the OTel semantic conventions version for now, until the OTel stuff has stabilized (which is not yet).