### PR TITLE
Reverting OTel semconv version to 1.29 to allow samples to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,8 +77,8 @@ dependencies {
 
     //Distributed Tracing Dependency on OpenTelemetry and Solace OpenTelemetry JCSMP Integration
     implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.1.0'
-    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.+'
-    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.+'
+    implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.47.+'
+    implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.29.+'
 }
 
 sourceSets {


### PR DESCRIPTION
The title says it all.  This is a quick / temp fix to allow the samples to build (albeit with many deprecated warnings now), until we + R&D decide what to do about migrating to 1.30 RC.