### PR TITLE
EBP-1350: Added Solace Generic SERDES For Java samples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
     implementation group: 'com.solace', name: 'solace-opentelemetry-jcsmp-integration', version: '1.1.0'
     implementation group: 'io.opentelemetry', name: 'opentelemetry-exporter-otlp', version: '1.47.+'
     implementation group: 'io.opentelemetry.semconv', name: 'opentelemetry-semconv', version: '1.29.+'
+
+    // Solace SERDES Dependencies
+    implementation group: 'com.solace', name: 'solace-serdes', version: '1.+'
 }
 
 sourceSets {
@@ -131,7 +134,7 @@ def scripts = [
     'dtDirectPublisher':'com/solace/samples/jcsmp/features/distributedtracing/DirectPublisherWithManualInstrumentation',
     'GuaranteedSubscriberWithSettle':'com.solace.samples.jcsmp.patterns.GuaranteedSubscriberWithSettle',
     'dtDirectSubscriber':'com/solace/samples/jcsmp/features/distributedtracing/DirectSubscriberWithManualInstrumentation',
-    'HelloWorldJCSMPStringSerdes':'com.solace.samples.jcsmp.features.serdes.primitives.HelloWorldJCSMPStringSerdes'
+    'HelloWorldJCSMPStringSerdes':'com.solace.samples.jcsmp.features.serdes.generic.HelloWorldJCSMPStringSerdes'
 ]
 // for each of those array entries, let's make a start script
 scripts.each() { scriptName, className ->

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ jar {
     exclude '**/log4j2.xml'  // don't put it inside the JAR file, we'll have it external in config dir
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 // Download context sensitive help and/or source code for eclipse and idea
 eclipse {
     classpath {
@@ -37,8 +42,8 @@ eclipse {
     }
     jdt {
         //if you want to alter the java versions (by default they are configured with gradle java plugin settings):
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = 11
+        targetCompatibility = 11
     }
 }
 
@@ -46,6 +51,8 @@ idea {
     module {
         downloadJavadoc = true
         downloadSources = true
+        sourceCompatibility = 11
+        targetCompatibility = 11
     }
 }
 
@@ -123,7 +130,8 @@ def scripts = [
     'topicToQueueMapping':'com.solace.samples.jcsmp.features.TopicToQueueMapping',
     'dtDirectPublisher':'com/solace/samples/jcsmp/features/distributedtracing/DirectPublisherWithManualInstrumentation',
     'GuaranteedSubscriberWithSettle':'com.solace.samples.jcsmp.patterns.GuaranteedSubscriberWithSettle',
-    'dtDirectSubscriber':'com/solace/samples/jcsmp/features/distributedtracing/DirectSubscriberWithManualInstrumentation'
+    'dtDirectSubscriber':'com/solace/samples/jcsmp/features/distributedtracing/DirectSubscriberWithManualInstrumentation',
+    'HelloWorldJCSMPStringSerdes':'com.solace.samples.jcsmp.features.serdes.primitives.HelloWorldJCSMPStringSerdes'
 ]
 // for each of those array entries, let's make a start script
 scripts.each() { scriptName, className ->

--- a/src/main/java/com/solace/samples/jcsmp/features/serdes/generic/HelloWorldJCSMPStringSerdes.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/serdes/generic/HelloWorldJCSMPStringSerdes.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.solace.samples.jcsmp.features.serdes.primitives;
+package com.solace.samples.jcsmp.features.serdes.generic;
 
 import com.solace.serdes.Deserializer;
 import com.solace.serdes.Serializer;

--- a/src/main/java/com/solace/samples/jcsmp/features/serdes/primitives/HelloWorldJCSMPStringSerdes.java
+++ b/src/main/java/com/solace/samples/jcsmp/features/serdes/primitives/HelloWorldJCSMPStringSerdes.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 Solace Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.solace.samples.jcsmp.features.serdes.primitives;
+
+import com.solace.serdes.Deserializer;
+import com.solace.serdes.Serializer;
+import com.solace.serdes.StringSerializer;
+import com.solace.serdes.StringDeserializer;
+import com.solacesystems.jcsmp.BytesMessage;
+import com.solacesystems.jcsmp.JCSMPException;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.solacesystems.jcsmp.JCSMPSession;
+import com.solacesystems.jcsmp.JCSMPStreamingPublishCorrelatingEventHandler;
+import com.solacesystems.jcsmp.Topic;
+import com.solacesystems.jcsmp.XMLMessageConsumer;
+import com.solacesystems.jcsmp.XMLMessageListener;
+import com.solacesystems.jcsmp.XMLMessageProducer;
+
+import java.io.IOException;
+
+/**
+ * HelloWorldJCSMPStringSerdes
+ * This class demonstrates the usage of Solace JCSMP API with String serialization and deserialization.
+ * It connects to a Solace message broker, publishes a message using String serialization, and consumes
+ * the message using String deserialization.
+ */
+public class HelloWorldJCSMPStringSerdes {
+
+    /**
+     * The main method that demonstrates the Solace JCSMP API usage with String serialization/deserialization.
+     *
+     * @param args Command line arguments: <host:port> <username>@<message-vpn> [password]
+     * @throws Exception If any error occurs during execution
+     */
+    public static void main(String[] args) throws JCSMPException, IOException {
+        Topic topic = JCSMPFactory.onlyInstance().createTopic("topic");
+
+        final JCSMPSession consumerSession = getSession(args);
+        XMLMessageConsumer consumer = consumerSession.getMessageConsumer((XMLMessageListener) null);
+        consumerSession.addSubscription(topic);
+        consumer.start();
+
+        final JCSMPSession producerSession = getSession(args);
+        XMLMessageProducer producer = producerSession.getMessageProducer(new ExampleProducer());
+
+        BytesMessage msg = producer.createBytesMessage();
+        String messageText = "Hello World";
+
+        try (StringSerializer strSerializer = new StringSerializer()) {
+            msg.setData(strSerializer.serialize(topic.getName(), messageText));
+        }
+
+        producer.send(msg, topic);
+
+        System.out.println("Message Text sent: " + messageText);
+        System.out.println("Data sent:\n" + msg.dump());
+
+        BytesMessage receive = (BytesMessage) consumer.receive();
+        byte[] recvData = receive.getData();
+        String receivedText;
+        try (StringDeserializer strDeserializer = new StringDeserializer()) {
+            receivedText = strDeserializer.deserialize(receive.getDestination().getName(), recvData);
+        }
+
+        System.out.println("MessageText recv: " + receivedText);
+        System.out.println("Recv data:\n" + receive.dump());
+
+        msg = producer.createBytesMessage();
+        messageText = "Hello World 2";
+
+        try (Serializer<String> serializer = new StringSerializer()) {
+            msg.setData(serializer.serialize(topic.getName(), messageText));
+        }
+
+        producer.send(msg, topic);
+
+        System.out.println("Message Text sent: " + messageText);
+        System.out.println("Data sent:\n" + msg.dump());
+
+        receive = (BytesMessage) consumer.receive();
+        recvData = receive.getData();
+        try (Deserializer<String> deserializer = new StringDeserializer()) {
+            receivedText = deserializer.deserialize(receive.getDestination().getName(), recvData);
+        }
+
+        System.out.println("MessageText recv: " + receivedText);
+        System.out.println("Recv data:\n" + receive.dump());
+
+        consumerSession.closeSession();
+        producerSession.closeSession();
+    }
+
+    /**
+     * Creates and returns a JCSMP session with the provided connection details.
+     *
+     * @param args Command line arguments: <host:port> <username>@<message-vpn> [password]
+     * @return A connected JCSMPSession
+     * @throws JCSMPException If there's an error creating or connecting the session
+     */
+    private static JCSMPSession getSession(String[] args) throws JCSMPException {
+        if (args.length < 2) {  // Check command line arguments
+            System.out.println("Usage: <host:port> <username>@<message-vpn> [password]");
+            System.exit(-1);
+        }
+
+        final JCSMPProperties properties = new JCSMPProperties();
+        properties.setProperty(JCSMPProperties.HOST, args[0]);
+        properties.setProperty(JCSMPProperties.USERNAME, args[1].split("@")[0]);
+        properties.setProperty(JCSMPProperties.VPN_NAME,  args[1].split("@")[1]);
+        if (args.length > 2) {
+            properties.setProperty(JCSMPProperties.PASSWORD, args[2]);
+        }
+        final JCSMPSession session = JCSMPFactory.onlyInstance().createSession(properties);
+
+        session.connect();
+        return session;
+    }
+
+    private static class ExampleProducer implements JCSMPStreamingPublishCorrelatingEventHandler {
+        @Override
+        public void responseReceivedEx(Object o) {/* not needed */}
+
+        @Override
+        public void handleErrorEx(Object o, JCSMPException e, long l) {/* not needed */}
+    }
+}


### PR DESCRIPTION
## What is the purpose of this change?

Add a new sample application demonstrating string serialization and deserialization capabilities with Solace JCSMP API. This sample provides developers with a practical example of how to use the Solace Generic SERDES For Java library for string message handling in both publisher and consumer scenarios.

## How is this accomplished?

- **New Sample**: Created `HelloWorldJCSMPStringSerdes.java` that demonstrates:
  - String message publishing using `StringSerializer` 
  - String message consumption using `StringDeserializer`
- **Build Updates**: Updated Java compatibility from version 8 to 11 to support Solace Generic SERDES For Java